### PR TITLE
Inclusión de estilos del menú en compilación para producción

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -7,9 +7,8 @@
     @stack('styles')
     <link href="https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css" rel="stylesheet" />
     <title>SivarSocial</title>
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @vite(['resources/css/app.css', 'resources/css/menu-mobile.css', 'resources/js/app.js'])
 
-    @vite(['resources/css/menu-mobile.css'])
     <meta name="csrf-token" content="{{ csrf_token() }}">
     @livewireStyles()
     <!-- Alpine.js - Cargar ANTES del contenido -->

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,11 @@ import tailwindcss from '@tailwindcss/vite';
 export default defineConfig({
     plugins: [
         laravel({
-            input: ['resources/css/app.css', 'resources/js/app.js'],
+            input: [
+                'resources/css/app.css', 
+                'resources/css/menu-mobile.css',
+                'resources/js/app.js'
+            ],
             refresh: true,
         }),
         tailwindcss(),


### PR DESCRIPTION
### **Descripción**
Se corrigió un problema relacionado con el despliegue de assets en producción.
El archivo CSS correspondiente al menú no se había incluido correctamente en el proyecto, por lo que al compilar los assets para producción, este no se incorporaba. Este problema no se manifestaba en el entorno de desarrollo, pero sí afectaba el entorno de producción, donde el menú no se mostraba correctamente por la falta de estilos.

`vite.config.js`