### PR TITLE
Update Flujo de Publicaciones

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 
+# Configuración de base de datos
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1
 DB_PORT=3306
@@ -11,11 +12,23 @@ DB_DATABASE=sivarsocial
 DB_USERNAME=root
 DB_PASSWORD=
 
+# Configuración de sesiones mejorada
+SESSION_DRIVER=database
+SESSION_LIFETIME=43200
+SESSION_EXPIRE_ON_CLOSE=false
+SESSION_ENCRYPT=false
+SESSION_SECURE_COOKIE=false
+SESSION_HTTP_ONLY=true
+SESSION_SAME_SITE=lax
+
+# Configuración de la aplicación
 POSTS_PER_PAGE=6
 
+# Spotify API
 SPOTIFY_CLIENT_ID=clave_de_spotify
 SPOTIFY_CLIENT_SECRET=secreto_de_spotify
 
+# Configuración de correo
 MAIL_MAILER=smtp
 MAIL_SCHEME=null
 MAIL_HOST=smtp.gmail.com

--- a/app/Http/Middleware/ExtendSessionLifetime.php
+++ b/app/Http/Middleware/ExtendSessionLifetime.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Session;
+use Symfony\Component\HttpFoundation\Response;
+
+class ExtendSessionLifetime
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        // Extender la duración de la sesión para usuarios autenticados
+        if (Auth::check()) {
+            // Extender la sesión por 30 días para usuarios autenticados
+            config(['session.lifetime' => 43200]); // 30 días en minutos
+            
+            // Regenerar el ID de sesión periódicamente para seguridad
+            if (!Session::has('last_regenerated') || 
+                Session::get('last_regenerated') < now()->subHours(24)) {
+                Session::regenerate();
+                Session::put('last_regenerated', now());
+            }
+        }
+
+        $response = $next($request);
+
+        // Configurar cookies de sesión para mayor persistencia
+        if (Auth::check()) {
+            // Configurar cookie con mayor duración
+            $response->headers->setCookie(
+                cookie(
+                    name: config('session.cookie'),
+                    value: Session::getId(),
+                    minutes: 43200, // 30 días
+                    path: config('session.path'),
+                    domain: config('session.domain'),
+                    secure: config('session.secure'),
+                    httpOnly: config('session.http_only'),
+                    sameSite: config('session.same_site')
+                )
+            );
+        }
+
+        return $response;
+    }
+}

--- a/app/Livewire/CommentsSection.php
+++ b/app/Livewire/CommentsSection.php
@@ -55,6 +55,13 @@ class CommentsSection extends Component
 
     public function store()
     {
+        // Solo usuarios autenticados pueden comentar
+        if (!Auth::check()) {
+            // Emitir evento para mostrar modal de registro/login
+            $this->dispatch('show-auth-modal', action: 'comment');
+            return;
+        }
+
         // Validación
         $this->validate([
             'comentario' => 'required|string|max:500|min:1',
@@ -63,11 +70,6 @@ class CommentsSection extends Component
             'comentario.max' => 'El comentario no puede exceder los 500 caracteres.',
             'comentario.min' => 'El comentario debe tener al menos 1 caracter.',
         ]);
-
-        // Solo usuarios autenticados pueden comentar
-        if (!Auth::check()) {
-            return;
-        }
 
         // Verificar que el comentario no esté vacío o solo contenga espacios
         if (trim($this->comentario) === '') {

--- a/app/Livewire/FollowUser.php
+++ b/app/Livewire/FollowUser.php
@@ -34,6 +34,8 @@ class FollowUser extends Component
         $currentUser = Auth::user();
 
         if (!$currentUser) {
+            // Emitir evento para mostrar modal de registro/login
+            $this->dispatch('show-auth-modal', action: 'follow');
             return;
         }
 

--- a/app/Livewire/LikePost.php
+++ b/app/Livewire/LikePost.php
@@ -35,6 +35,8 @@ class LikePost extends Component
         $user = Auth::user();
 
         if (!$user) {
+            // Emitir evento para mostrar modal de registro/login
+            $this->dispatch('show-auth-modal', action: 'like');
             return;
         }
 

--- a/app/Livewire/PostFollowButton.php
+++ b/app/Livewire/PostFollowButton.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\Post;
+use App\Models\User;
+use Livewire\Component;
+use Illuminate\Support\Facades\Auth;
+
+class PostFollowButton extends Component
+{
+    public Post $post;
+    public ?User $postAuthor = null;
+    public bool $shouldShowFollowButton = false;
+    public bool $isFollowing = false;
+
+    public function mount(Post $post)
+    {
+        $this->post = $post;
+        $this->initializeComponent();
+    }
+
+    private function initializeComponent()
+    {
+        try {
+            // Cargar la relación del usuario si no está cargada
+            if (!$this->post->relationLoaded('user')) {
+                $this->post->load('user');
+            }
+            
+            $this->postAuthor = $this->post->user;
+            $this->checkIfShouldShowButton();
+        } catch (\Exception $e) {
+            // En caso de error, no mostrar el botón
+            $this->shouldShowFollowButton = false;
+            $this->isFollowing = false;
+        }
+    }
+
+    public function checkIfShouldShowButton()
+    {
+        $authUser = Auth::user();
+        
+        // Inicializar valores por defecto
+        $this->shouldShowFollowButton = false;
+        $this->isFollowing = false;
+        
+        // No mostrar botón si:
+        // - No hay usuario autenticado
+        // - Es el propio usuario
+        // - No hay autor del post
+        if (!$authUser || !$this->postAuthor || $authUser->id === $this->postAuthor->id) {
+            return;
+        }
+
+        // Verificar si ya sigue al usuario
+        try {
+            $this->isFollowing = $authUser->isFollowing($this->postAuthor);
+            
+            // Solo mostrar si no lo sigue
+            $this->shouldShowFollowButton = !$this->isFollowing;
+        } catch (\Exception $e) {
+            // En caso de error, no mostrar el botón
+            $this->shouldShowFollowButton = false;
+        }
+    }
+
+    public function followUser()
+    {
+        $authUser = Auth::user();
+
+        if (!$authUser) {
+            $this->dispatch('show-auth-modal', action: 'follow');
+            return;
+        }
+
+        if (!$this->postAuthor || $authUser->id === $this->postAuthor->id) {
+            return;
+        }
+
+        try {
+            // Seguir al usuario
+            $authUser->following()->attach($this->postAuthor->id);
+            $this->isFollowing = true;
+            $this->shouldShowFollowButton = false;
+
+            // Notificar a otros componentes
+            $this->dispatch('follow-updated', userId: $this->postAuthor->id, isFollowing: true);
+            
+            // Mostrar mensaje de éxito
+            $this->dispatch('show-toast', message: "Ahora sigues a {$this->postAuthor->name}!", type: 'success');
+        } catch (\Exception $e) {
+            // Manejar error silenciosamente
+            return;
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.post-follow-button');
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,10 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        // Agregar middleware para extender duración de sesión
+        $middleware->web(append: [
+            \App\Http\Middleware\ExtendSessionLifetime::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         // Configurar manejo personalizado de errores HTTP

--- a/database/migrations/2025_08_10_184620_add_visibility_to_posts_table.php
+++ b/database/migrations/2025_08_10_184620_add_visibility_to_posts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->enum('visibility', ['public', 'followers'])->default('public')->after('tipo');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('visibility');
+        });
+    }
+};

--- a/resources/views/components/listar-post.blade.php
+++ b/resources/views/components/listar-post.blade.php
@@ -3,21 +3,10 @@
         @foreach ($posts as $post)
             <div class="bg-white rounded-2xl shadow-lg mb-6 sm:mb-10 w-full max-w-md sm:max-w-lg flex flex-col items-center">
 
-                <!-- Encabezado de la publicación -->
-                <div class="flex items-center w-full px-4 py-3 border-b border-gray-200">
-                    <a href="{{ $post->user ? route('posts.index', $post->user) : '#' }}" class="flex items-center group">
-                        <img src="{{ $post->user && $post->user->imagen ? asset('perfiles/' . $post->user->imagen) : asset('img/default-avatar.png') }}"
-                            alt="Avatar de {{ $post->user ? $post->user->username : 'usuario' }}"
-                            class="w-8 h-8 sm:w-10 sm:h-10 rounded-full object-cover border-2 border-[#3B25DD] group-hover:border-[#120073] transition">
-                        <span class="ml-3 font-bold text-black group-hover:underline text-sm sm:text-base">
-                            <div class="flex items-center gap-1 min-h-5">
-                                <span>{{ $post->user ? ($post->user->name ?? $post->user->username) : 'usuario' }}</span>
-                                <x-user-badge :badge="$post->user->insignia ?? null" size="medium" />
-                            </div>
-                        </span>
-                    </a>
-                    <span class="text-xs text-gray-500 ml-auto">{{ ucfirst($post->created_at->diffForHumans()) }}</span>
-                </div>
+                <!-- Encabezado de la publicación usando componente -->
+                <x-post-header :post="$post" :showMenu="false" :showFollowButton="true">
+                    <!-- Botón de seguir se maneja internamente en el componente -->
+                </x-post-header>
 
                 <!-- Contenido de la publicación -->
                 @if ($post->tipo === 'imagen')

--- a/resources/views/components/post-header.blade.php
+++ b/resources/views/components/post-header.blade.php
@@ -1,0 +1,62 @@
+@props(['post', 'showMenu' => true, 'linkRoute' => null, 'showFollowButton' => false])
+
+@php
+    $userRoute = $linkRoute ?? route('posts.index', $post->user->username ?? $post->user);
+@endphp
+
+<!-- Header de publicación reutilizable -->
+<div class="flex items-center w-full px-4 py-3 border-b border-gray-200">
+    <div class="flex items-center flex-1">
+        <img src="{{ $post->user && $post->user->imagen ? asset('perfiles/' . $post->user->imagen) : asset('img/img.jpg') }}"
+            alt="Avatar de {{ $post->user ? $post->user->username : 'usuario' }}"
+            class="w-8 h-8 sm:w-10 sm:h-10 rounded-full object-cover border-2 border-[#3B25DD] transition"
+            onerror="this.src='{{ asset('img/img.jpg') }}'">
+
+        <div class="ml-3 flex flex-col flex-1">
+            <div class="flex items-center justify-between w-full">
+                <!-- Información del usuario (izquierda) -->
+                <div class="flex items-center gap-1">
+                    <a href="{{ $userRoute }}" class="group">
+                        <span class="font-bold text-black group-hover:underline text-sm sm:text-base">
+                            {{ $post->user ? ($post->user->name ?? $post->user->username) : 'usuario' }}
+                        </span>
+                    </a>
+                    <x-user-badge :badge="$post->user->insignia ?? null" size="medium" />
+                </div>
+
+                <!-- Fecha y visibilidad (derecha) -->
+                <div class="flex items-center gap-1 ml-2">
+                    <span class="text-xs text-gray-500">{{ $post->compact_time }}</span>
+
+                    <!-- Icono de visibilidad -->
+                    @if($post->visibility === 'public')
+                        <div class="inline-flex items-center group/visibility"
+                            title="Publicación pública - Visible para todos">
+                            <i class="fas fa-globe text-gray-400 text-xs "></i>
+                        </div>
+                    @elseif($post->visibility === 'followers')
+                        <div class="inline-flex items-center group/visibility"
+                            title="Solo para seguidores - Visible solo para tus seguidores">
+                            <i class="fas fa-users text-gray-400 text-xs"></i>
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div> <!-- Botón de seguir y menú de opciones -->
+    <div class="flex items-center gap-2 ml-2">
+        <!-- Botón de seguir (solo en listar-post) -->
+        @if($post->user && $showFollowButton)
+            <livewire:post-follow-button :post="$post" :key="'follow-' . $post->id" />
+        @endif
+
+        <!-- Menú de opciones (solo para el propietario) -->
+        @if($showMenu)
+            @auth
+                @if ($post->user_id === Auth::user()->id)
+                    {{ $slot ?? '' }}
+                @endif
+            @endauth
+        @endif
+    </div>
+</div>

--- a/resources/views/livewire/post-follow-button.blade.php
+++ b/resources/views/livewire/post-follow-button.blade.php
@@ -1,0 +1,9 @@
+<div class="inline-block">
+    @if($shouldShowFollowButton && $postAuthor && isset($postAuthor->name))
+        <button wire:click="followUser" type="button"
+            class="transition-all duration-200 font-medium rounded-full px-3 py-1.5 text-xs bg-[#3B25DD]  text-white hover:bg-[#120073]"
+            title="Seguir a {{ $postAuthor->name }}">
+            SEGUIR
+        </button>
+    @endif
+</div>

--- a/resources/views/posts/form.blade.php
+++ b/resources/views/posts/form.blade.php
@@ -28,6 +28,36 @@
             <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
         @enderror
     </div>
+
+    <!-- Campo de visibilidad -->
+    <div class="mb-6">
+        <label class="block text-gray-700 font-medium mb-3">
+            ¿Quién puede ver esta publicación?
+        </label>
+        <div class="space-y-2">
+            <label class="flex items-center p-3 border border-gray-200 rounded-lg cursor-pointer transition-colors visibility-option bg-white">
+                <input type="radio" name="visibility" value="public"
+                       class="text-gray-600 focus:ring-gray-400"
+                       {{ old('visibility', 'public') === 'public' ? 'checked' : '' }}>
+                <div class="ml-3">
+                    <span class="font-medium text-gray-800">Público</span>
+                    <p class="text-xs text-gray-500 mt-1">Cualquier persona puede ver esta publicación</p>
+                </div>
+            </label>
+            <label class="flex items-center p-3 border border-gray-200 rounded-lg cursor-pointer transition-colors visibility-option bg-white">
+                <input type="radio" name="visibility" value="followers"
+                       class="text-gray-600 focus:ring-gray-400"
+                       {{ old('visibility') === 'followers' ? 'checked' : '' }}>
+                <div class="ml-3">
+                    <span class="font-medium text-gray-800">Solo seguidores</span>
+                    <p class="text-xs text-gray-500 mt-1">Solo tus seguidores pueden ver esta publicación</p>
+                </div>
+            </label>
+        </div>
+        @error('visibility')
+            <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+        @enderror
+    </div>
     <!-- Campos ocultos para imagen -->
     <div id="imagen-fields">
         <input name="imagen" type="hidden" value="{{ old('imagen') }}">
@@ -310,5 +340,32 @@
         updateSubmitButton();
         // Asegurar que el status indicator esté visible desde el inicio
         statusIndicator.classList.remove('hidden');
+
+        // Agregar interactividad visual a las opciones de visibilidad
+        document.addEventListener('DOMContentLoaded', function() {
+            const visibilityOptions = document.querySelectorAll('.visibility-option');
+            const radioInputs = document.querySelectorAll('input[name="visibility"]');
+            
+            function updateVisibilityStyles() {
+                visibilityOptions.forEach((option, index) => {
+                    const radio = radioInputs[index];
+                    if (radio.checked) {
+                        option.classList.add('border-blue-500', 'bg-blue-50');
+                        option.classList.remove('border-gray-200');
+                    } else {
+                        option.classList.remove('border-blue-500', 'bg-blue-50');
+                        option.classList.add('border-gray-200');
+                    }
+                });
+            }
+            
+            // Aplicar estilos iniciales
+            updateVisibilityStyles();
+            
+            // Escuchar cambios en los radio buttons
+            radioInputs.forEach(radio => {
+                radio.addEventListener('change', updateVisibilityStyles);
+            });
+        });
     });
 </script>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -22,72 +22,49 @@
                     <!-- Post musical -->
                     <div id="post-container"
                         class="bg-white rounded-2xl shadow-lg w-full lg:max-w-md flex flex-col min-h-[500px] mt-4 lg:mt-0">
-                        <!-- Header: perfil y username -->
-                        <div class="flex items-center w-full px-4 py-3 border-b border-gray-200">
-                            <a href="{{ route('posts.index', $post->user->username) }}" class="flex items-center group">
-                                <img src="{{ $post->user && $post->user->imagen ? asset('perfiles/' . $post->user->imagen) : asset('img/img.jpg') }}"
-                                    alt="Avatar de {{ $post->user->username }}"
-                                    class="w-10 h-10 rounded-full object-cover border-2 border-[#3B25DD] group-hover:border-[#120073] transition"
-                                    onerror="this.src='{{ asset('img/img.jpg') }}'">
-                                <span class="ml-3 font-bold text-black group-hover:underline text-sm sm:text-base">
-                                    {{ $post->user->name ?? $post->user->username }}
-                                </span>
-                                <x-user-badge :badge="$post->user->insignia ?? null" size="medium" />
-                            </a>
-                            <div class="flex items-center gap-2 ml-auto">
-                                <span class="text-xs text-gray-500">{{ ucfirst($post->created_at->diffForHumans()) }}</span>
+                        <!-- Header usando componente reutilizable -->
+                        <x-post-header :post="$post" :showMenu="true" :showFollowButton="false">
+                            <div class="relative" x-data="{ showMusicMenu: false }" @close-menus.window="showMusicMenu = false">
+                                <button @click="showMusicMenu = !showMusicMenu"
+                                    class="p-1.5 text-gray-400 hover:text-gray-600 rounded-full hover:bg-gray-100 transition-colors">
+                                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                                        <path
+                                            d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
+                                    </svg>
+                                </button>
 
-                                <!-- Menú de opciones (solo para el propietario) -->
-                                @auth
-                                    @if ($post->user_id === Auth::user()->id)
-                                        <div class="relative" x-data="{ showMusicMenu: false }"
-                                            @close-menus.window="showMusicMenu = false">
-                                            <button @click="showMusicMenu = !showMusicMenu"
-                                                class="p-1.5 text-gray-400 hover:text-gray-600 rounded-full hover:bg-gray-100 transition-colors">
-                                                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                                                    <path
-                                                        d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
-                                                </svg>
-                                            </button>
+                                <!-- Dropdown menu -->
+                                <div x-show="showMusicMenu" x-cloak @click.away="showMusicMenu = false" x-transition
+                                    class="absolute right-0 mt-1 w-36 bg-white rounded-lg shadow-lg border border-gray-200 z-50 py-1">
 
-                                            <!-- Dropdown menu -->
-                                            <div x-show="showMusicMenu" x-cloak @click.away="showMusicMenu = false" x-transition
-                                                class="absolute right-0 mt-1 w-36 bg-white rounded-lg shadow-lg border border-gray-200 z-50 py-1">
+                                    <!-- Opción Editar (preparada para futura implementación) -->
+                                    <button onclick="alert('Función de editar en desarrollo')"
+                                        class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2">
+                                        <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor"
+                                            viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z">
+                                            </path>
+                                        </svg>
+                                        Editar
+                                    </button>
 
-                                                <!-- Opción Editar (preparada para futura implementación) -->
-                                                <button onclick="alert('Función de editar en desarrollo')"
-                                                    class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2">
-                                                    <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor"
-                                                        viewBox="0 0 24 24">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                                            d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z">
-                                                        </path>
-                                                    </svg>
-                                                    Editar
-                                                </button>
+                                    <!-- Separador -->
+                                    <hr class="my-1">
 
-                                                <!-- Separador -->
-                                                <hr class="my-1">
-
-                                                <!-- Opción Eliminar -->
-                                                <button onclick="openDeleteModal()"
-                                                    class="w-full text-left px-3 py-2 text-sm text-red-600 hover:bg-red-50 flex items-center gap-2">
-                                                    <svg class="w-4 h-4 text-red-500" fill="none" stroke="currentColor"
-                                                        viewBox="0 0 24 24">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                                            d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1-1H8a1 1 0 00-1 1v3M4 7h16">
-                                                        </path>
-                                                    </svg>
-                                                    Eliminar
-                                                </button>
-                                            </div>
-                                        </div>
-                                    @endif
-                                @endauth
+                                    <!-- Opción Eliminar -->
+                                    <button onclick="openDeleteModal()"
+                                        class="w-full text-left px-3 py-2 text-sm text-red-600 hover:bg-red-50 flex items-center gap-2">
+                                        <svg class="w-4 h-4 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1-1H8a1 1 0 00-1 1v3M4 7h16">
+                                            </path>
+                                        </svg>
+                                        Eliminar
+                                    </button>
+                                </div>
                             </div>
-                        </div>
-
-                        <!-- Contenido musical principal -->
+                        </x-post-header> <!-- Contenido musical principal -->
                         <div class="w-full p-4 sm:p-6 bg-gradient-to-br from-[#121212] to-[#1a1a1a] relative overflow-hidden">
                             <!-- Fondo decorativo con el color dominante -->
                             <div class="absolute inset-0 opacity-10"
@@ -173,19 +150,19 @@
                                             <!-- Barra de progreso responsive -->
                                             <div class="space-y-2 sm:space-y-3">
                                                 <div class="progress-container relative bg-white/20 hover:bg-white/30 rounded-full 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                h-1.5 sm:h-2 cursor-pointer transition-all duration-200"
+                                                                                                                                                                                                                                                                                                                                                                                                                                                            h-1.5 sm:h-2 cursor-pointer transition-all duration-200"
                                                     id="progress-container">
                                                     <div id="progress-bar"
                                                         class="absolute left-0 top-0 h-full bg-white rounded-full 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                    transition-all duration-100 ease-out"
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                transition-all duration-100 ease-out"
                                                         style="width: 0%">
                                                     </div>
                                                     <!-- Punto de progreso -->
                                                     <div id="progress-thumb"
                                                         class="absolute w-3 h-3 sm:w-4 sm:h-4 bg-white rounded-full 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                    shadow-lg transform -translate-y-1/2 translate-x-1/2 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                    opacity-0 transition-all duration-200 ease-out
-                                                                                                                                                                                                                                                                                                                                                                                                                                                    hover:scale-110 active:scale-95"
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                shadow-lg transform -translate-y-1/2 translate-x-1/2 
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                opacity-0 transition-all duration-200 ease-out
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                hover:scale-110 active:scale-95"
                                                         style="left: 0%; top: 50%"></div>
                                                 </div>
 
@@ -282,72 +259,49 @@
                     <!-- Post de imagen -->
                     <div id="post-container"
                         class="bg-white rounded-2xl shadow-lg w-full lg:max-w-md flex flex-col items-center min-h-[500px]">
-                        <!-- Header: perfil y username -->
-                        <div class="flex items-center w-full px-4 py-3 border-b border-gray-200">
-                            <a href="{{ route('posts.index', $post->user->username) }}" class="flex items-center group">
-                                <img src="{{ $post->user && $post->user->imagen ? asset('perfiles/' . $post->user->imagen) : asset('img/img.jpg') }}"
-                                    alt="Avatar de {{ $post->user->username }}"
-                                    class="w-10 h-10 rounded-full object-cover border-2 border-[#3B25DD] group-hover:border-[#120073] transition"
-                                    onerror="this.src='{{ asset('img/img.jpg') }}'">
-                                <span class="ml-3 font-bold text-black group-hover:underline text-sm sm:text-base">
-                                    {{ $post->user->name ?? $post->user->username }}
-                                </span>
-                                <x-user-badge :badge="$post->user->insignia ?? null" size="medium" />
-                            </a>
-                            <div class="flex items-center gap-2 ml-auto">
-                                <span class="text-xs text-gray-500">{{ ucfirst($post->created_at->diffForHumans()) }}</span>
+                        <!-- Header usando componente reutilizable -->
+                        <x-post-header :post="$post" :showMenu="true" :showFollowButton="false">
+                            <div class="relative" x-data="{ showImageMenu: false }" @close-menus.window="showImageMenu = false">
+                                <button @click="showImageMenu = !showImageMenu"
+                                    class="p-1.5 text-gray-400 hover:text-gray-600 rounded-full hover:bg-gray-100 transition-colors">
+                                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                                        <path
+                                            d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
+                                    </svg>
+                                </button>
 
-                                <!-- Menú de opciones (solo para el propietario) -->
-                                @auth
-                                    @if ($post->user_id === Auth::user()->id)
-                                        <div class="relative" x-data="{ showImageMenu: false }"
-                                            @close-menus.window="showImageMenu = false">
-                                            <button @click="showImageMenu = !showImageMenu"
-                                                class="p-1.5 text-gray-400 hover:text-gray-600 rounded-full hover:bg-gray-100 transition-colors">
-                                                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                                                    <path
-                                                        d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
-                                                </svg>
-                                            </button>
+                                <!-- Dropdown menu -->
+                                <div x-show="showImageMenu" x-cloak @click.away="showImageMenu = false" x-transition
+                                    class="absolute right-0 mt-1 w-36 bg-white rounded-lg shadow-lg border border-gray-200 z-50 py-1">
 
-                                            <!-- Dropdown menu -->
-                                            <div x-show="showImageMenu" x-cloak @click.away="showImageMenu = false" x-transition
-                                                class="absolute right-0 mt-1 w-36 bg-white rounded-lg shadow-lg border border-gray-200 z-50 py-1">
+                                    <!-- Opción Editar (preparada para futura implementación) -->
+                                    <button onclick="alert('Función de editar en desarrollo')"
+                                        class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2">
+                                        <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor"
+                                            viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z">
+                                            </path>
+                                        </svg>
+                                        Editar
+                                    </button>
 
-                                                <!-- Opción Editar (preparada para futura implementación) -->
-                                                <button onclick="alert('Función de editar en desarrollo')"
-                                                    class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2">
-                                                    <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor"
-                                                        viewBox="0 0 24 24">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                                            d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z">
-                                                        </path>
-                                                    </svg>
-                                                    Editar
-                                                </button>
+                                    <!-- Separador -->
+                                    <hr class="my-1">
 
-                                                <!-- Separador -->
-                                                <hr class="my-1">
-
-                                                <!-- Opción Eliminar -->
-                                                <button onclick="openDeleteModal()"
-                                                    class="w-full text-left px-3 py-2 text-sm text-red-600 hover:bg-red-50 flex items-center gap-2">
-                                                    <svg class="w-4 h-4 text-red-500" fill="none" stroke="currentColor"
-                                                        viewBox="0 0 24 24">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                                            d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1-1H8a1 1 0 00-1 1v3M4 7h16">
-                                                        </path>
-                                                    </svg>
-                                                    Eliminar
-                                                </button>
-                                            </div>
-                                        </div>
-                                    @endif
-                                @endauth
+                                    <!-- Opción Eliminar -->
+                                    <button onclick="openDeleteModal()"
+                                        class="w-full text-left px-3 py-2 text-sm text-red-600 hover:bg-red-50 flex items-center gap-2">
+                                        <svg class="w-4 h-4 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1-1H8a1 1 0 00-1 1v3M4 7h16">
+                                            </path>
+                                        </svg>
+                                        Eliminar
+                                    </button>
+                                </div>
                             </div>
-                        </div>
-
-                        <!-- Imagen del post - SIEMPRE CUADRADA -->
+                        </x-post-header> <!-- Imagen del post - SIEMPRE CUADRADA -->
                         <div class="w-full bg-white rounded-b-none rounded-t-none aspect-square">
                             <img src="{{ asset('uploads') . '/' . $post->imagen }}" alt="Imagen del post {{ $post->titulo }}"
                                 class="w-full h-full object-cover rounded-none" width="1080" height="1080" loading="lazy">
@@ -1398,32 +1352,32 @@
                 const isFollowing = like.isFollowing || false;
 
                 html += `
-                                                                                <div class="py-3 flex items-center justify-between">
-                                                                                    <div class="flex items-center gap-3">
-                                                                                        <a href="/${user.username}">
-                                                                                            <img src="${avatarUrl}" 
-                                                                                                 alt="${user.username}"
-                                                                                                 class="w-12 h-12 rounded-full object-cover"
-                                                                                                 onerror="this.src='/img/img.jpg'">
-                                                                                        </a>
-                                                                                        <div>
-                                                                                            <a href="/${user.username}" class="block">
-                                                                                                <p class="font-semibold text-sm text-gray-900">${user.name || user.username}</p>
-                                                                                                <p class="text-sm text-gray-500">${user.username}</p>
+                                                                                    <div class="py-3 flex items-center justify-between">
+                                                                                        <div class="flex items-center gap-3">
+                                                                                            <a href="/${user.username}">
+                                                                                                <img src="${avatarUrl}" 
+                                                                                                     alt="${user.username}"
+                                                                                                     class="w-12 h-12 rounded-full object-cover"
+                                                                                                     onerror="this.src='/img/img.jpg'">
                                                                                             </a>
+                                                                                            <div>
+                                                                                                <a href="/${user.username}" class="block">
+                                                                                                    <p class="font-semibold text-sm text-gray-900">${user.name || user.username}</p>
+                                                                                                    <p class="text-sm text-gray-500">${user.username}</p>
+                                                                                                </a>
+                                                                                            </div>
                                                                                         </div>
-                                                                                    </div>
-                                                                                    ${currentUserId && currentUserId !== user.id ? `
-                                                                                        <button onclick="toggleFollow(${user.id}, this)" 
-                                                                                                data-user-id="${user.id}"
-                                                                                                class="px-4 py-1.5 text-sm font-medium rounded-lg ${isFollowing
+                                                                                        ${currentUserId && currentUserId !== user.id ? `
+                                                                                            <button onclick="toggleFollow(${user.id}, this)" 
+                                                                                                    data-user-id="${user.id}"
+                                                                                                    class="px-4 py-1.5 text-sm font-medium rounded-lg ${isFollowing
                             ? 'bg-gray-200 text-gray-700'
                             : 'bg-blue-500 text-white'
                         }">
-                                                                                            <span class="follow-text">${isFollowing ? 'Siguiendo' : 'Seguir'}</span>
-                                                                                        </button>
-                                                                                    ` : ''}
-                                                                                </div>`;
+                                                                                                <span class="follow-text">${isFollowing ? 'Siguiendo' : 'Seguir'}</span>
+                                                                                            </button>
+                                                                                        ` : ''}
+                                                                                    </div>`;
             });
 
             container.innerHTML = html;
@@ -1456,11 +1410,11 @@
 
             // Animación de carga
             button.innerHTML = `
-                                                                                        <div class="flex items-center gap-2">
-                                                                                            <div class="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin"></div>
-                                                                                            <span class="text-sm">Procesando...</span>
-                                                                                        </div>
-                                                                                    `;
+                                                                                            <div class="flex items-center gap-2">
+                                                                                                <div class="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin"></div>
+                                                                                                <span class="text-sm">Procesando...</span>
+                                                                                            </div>
+                                                                                        `;
 
             performFollowAction(userId, action, button, textElement, iconElement, originalText);
         }
@@ -1490,11 +1444,11 @@
                         if (textElement) {
                             // Estructura nueva del botón
                             button.innerHTML = `
-                                                                                                        <span class="follow-text">${isNowFollowing ? 'Siguiendo' : 'Seguir'}</span>
-                                                                                                        <svg class="follow-icon w-4 h-4 ml-1 ${isNowFollowing ? '' : 'hidden'}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                                                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                                                                                                        </svg>
-                                                                                                    `;
+                                                                                                            <span class="follow-text">${isNowFollowing ? 'Siguiendo' : 'Seguir'}</span>
+                                                                                                            <svg class="follow-icon w-4 h-4 ml-1 ${isNowFollowing ? '' : 'hidden'}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                                                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                                                                                                            </svg>
+                                                                                                        `;
 
                             // Actualizar clases del botón
                             button.className = `follow-btn flex items-center justify-center px-4 py-1.5 text-sm font-medium rounded-full transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 transform hover:scale-105 ${isNowFollowing
@@ -1532,11 +1486,11 @@
                         // Restaurar botón con estructura nueva
                         const isFollowing = originalText === 'Siguiendo';
                         button.innerHTML = `
-                                                                                                    <span class="follow-text">${originalText}</span>
-                                                                                                    <svg class="follow-icon w-4 h-4 ml-1 ${isFollowing ? '' : 'hidden'}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                                                                                                    </svg>
-                                                                                                `;
+                                                                                                        <span class="follow-text">${originalText}</span>
+                                                                                                        <svg class="follow-icon w-4 h-4 ml-1 ${isFollowing ? '' : 'hidden'}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                                                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                                                                                                        </svg>
+                                                                                                    `;
 
                         // Mostrar error temporal
                         const errorTextElement = button.querySelector('.follow-text');

--- a/routes/web.php
+++ b/routes/web.php
@@ -87,8 +87,8 @@ Route::post('/restablecer', [RecoverController::class, 'restablecer'])->name('re
  * EDICIÓN DE PERFIL
  * Permite al usuario modificar su información personal y configuración
  */
-Route::get('/editar-perfil', [PerfilController::class, 'index'])->name('perfil.index');
-Route::post('/editar-perfil', [PerfilController::class, 'store'])->name('perfil.store');
+Route::get('/editar-perfil', [PerfilController::class, 'index'])->name('perfil.index')->middleware('auth');
+Route::post('/editar-perfil', [PerfilController::class, 'store'])->name('perfil.store')->middleware('auth');
 
 /**
  * BÚSQUEDA DE USUARIOS
@@ -120,15 +120,15 @@ Route::get('/colaboradores', [ColaboradoresController::class, 'index'])->name('c
  * CREACIÓN DE POSTS
  * Formulario para crear nuevas publicaciones
  */
-Route::get('/posts/create', [PostController::class, 'create'])->name('posts.create');
-Route::post('/posts', [PostController::class, 'store'])->name('posts.store');
+Route::get('/posts/create', [PostController::class, 'create'])->name('posts.create')->middleware('auth');
+Route::post('/posts', [PostController::class, 'store'])->name('posts.store')->middleware('auth');
 
 /**
  * VISUALIZACIÓN Y GESTIÓN DE POSTS
  * Ver post individual y eliminar posts propios
  */
 Route::get('/{user:username}/posts/{post}', [PostController::class, 'show'])->name('posts.show');
-Route::delete('/posts/{post}', [PostController::class, 'destroy'])->name('posts.destroy');
+Route::delete('/posts/{post}', [PostController::class, 'destroy'])->name('posts.destroy')->middleware('auth');
 
 /**
  * PERFIL DE USUARIO
@@ -144,8 +144,8 @@ Route::get('/{user:username}', [PostController::class, 'index'])->name('posts.in
  * GESTIÓN DE LIKES
  * Dar like y quitar like a publicaciones
  */
-Route::post('/posts/{post}/likes', [LikeController::class, 'store'])->name('posts.likes.store');
-Route::delete('/posts/{post}/likes', [LikeController::class, 'destroy'])->name('posts.likes.destroy');
+Route::post('/posts/{post}/likes', [LikeController::class, 'store'])->name('posts.likes.store')->middleware('auth');
+Route::delete('/posts/{post}/likes', [LikeController::class, 'destroy'])->name('posts.likes.destroy')->middleware('auth');
 
 /**
  * OBTENER LIKES VIA AJAX
@@ -161,7 +161,7 @@ Route::get('/posts/{post}/likes', [PostController::class, 'getLikes'])->name('po
  * AGREGAR COMENTARIOS
  * Permite comentar en las publicaciones de otros usuarios
  */
-Route::post('/{user:username}/posts/{post}', [ComentarioController::class, 'store'])->name('comentarios.store');
+Route::post('/{user:username}/posts/{post}', [ComentarioController::class, 'store'])->name('comentarios.store')->middleware('auth');
 
 // ============================================================================
 // GESTIÓN DE IMÁGENES
@@ -193,15 +193,15 @@ Route::delete('/imagenes', [ImagenController::class, 'destroy'])->name('imagenes
  * SEGUIR/DEJAR DE SEGUIR POR USERNAME
  * Sistema básico de seguimiento usando el nombre de usuario
  */
-Route::post('/{user:username}/follow', [FollowerController::class, 'store'])->name('users.follow');
-Route::delete('/{user:username}/unfollow', [FollowerController::class, 'destroy'])->name('users.unfollow');
+Route::post('/{user:username}/follow', [FollowerController::class, 'store'])->name('users.follow')->middleware('auth');
+Route::delete('/{user:username}/unfollow', [FollowerController::class, 'destroy'])->name('users.unfollow')->middleware('auth');
 
 /**
  * SEGUIR/DEJAR DE SEGUIR POR ID
  * Para funcionalidades AJAX y llamadas asíncronas
  */
-Route::post('/users/{user}/follow', [FollowerController::class, 'storeById'])->name('users.follow.id');
-Route::post('/users/{user}/unfollow', [FollowerController::class, 'destroyById'])->name('users.unfollow.id');
+Route::post('/users/{user}/follow', [FollowerController::class, 'storeById'])->name('users.follow.id')->middleware('auth');
+Route::post('/users/{user}/unfollow', [FollowerController::class, 'destroyById'])->name('users.unfollow.id')->middleware('auth');
 
 // ============================================================================
 // INTEGRACIÓN CON APIs MUSICALES


### PR DESCRIPTION
Este *pull request* introduce controles de visibilidad de publicaciones (público vs. solo seguidores), mejora la gestión de sesiones para usuarios autenticados y optimiza la experiencia de usuario al solicitar autenticación para interacciones clave.  
También añade un botón de **"Seguir"** en los encabezados de publicaciones y aplica la lógica de visibilidad en toda la aplicación.  


## **Visibilidad de Publicaciones y Control de Acceso**
- Se añadió un campo `visibility` a la tabla `posts` (migración, modelo y validación) para permitir que las publicaciones se marquen como "públicas" o "solo seguidores", con lógica para determinar si un usuario puede ver una publicación.
- Se actualizaron las consultas del feed y de perfil para respetar la visibilidad de las publicaciones:
  - **Usuarios autenticados**: ven publicaciones públicas, publicaciones solo para seguidores de usuarios a los que siguen y sus propias publicaciones.  
  - **Usuarios no autenticados**: ven únicamente publicaciones públicas.


## **Mejoras en la Gestión de Sesiones**
- Se introdujo un nuevo *middleware* (`ExtendSessionLifetime`) para extender la duración de las sesiones de usuarios autenticados a **30 días**, con regeneración periódica del ID de sesión para mayor seguridad.
- Se actualizó `.env.example` con variables mejoradas de configuración de sesión para mayor control sobre su comportamiento.


## **Mejoras en la Interfaz de Usuario**
- Se reemplazó el marcado del encabezado de publicaciones en la lista por un componente reutilizable `x-post-header`, que ahora incluye un botón de seguir integrado.
